### PR TITLE
Use module.this.enabled instead of var.enabled for count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "default" {}
 
 resource "aws_iam_account_alias" "default" {
-  count = var.enabled == true ? 1 : 0
+  count = module.this.enabled == true ? 1 : 0
 
   account_alias = module.this.id
 }


### PR DESCRIPTION
## what
When using the context.tf, one should use module.this.enabled instead of accessing var.enabled directly.

## why
We get the incorrect behavior if we create the account_settings by passing a `context` map instead of setting the environment variables directly.